### PR TITLE
CSVLibrary should use RF DotDict for "read csv file to associative"

### DIFF
--- a/CSVLibrary/__init__.py
+++ b/CSVLibrary/__init__.py
@@ -1,6 +1,8 @@
 import csv
-from robot.api import logger
 import sys
+
+from robot.api import logger
+from robot.utils.dotdict import DotDict
 
 if sys.version_info.major >= 3:
     from io import StringIO as IO
@@ -8,6 +10,10 @@ else:
     from io import BytesIO as IO
 
 __version__ = '0.0.4'
+
+class DotDictReader(csv.DictReader):
+    def __next__(self):
+        return DotDict(super().__next__())
 
 
 class CSVLibrary(object):
@@ -134,7 +140,7 @@ class CSVLibrary(object):
         kwargs['fieldnames'] = fieldnames
         csv_dict = self._open_csv_file_for_read(
             filename,
-            csv_reader=csv.DictReader,
+            csv_reader=DotDictReader,
             delimiter=str(delimiter),
             **kwargs
         )
@@ -159,7 +165,7 @@ class CSVLibrary(object):
         with IO(csv_string) as csv_handler:
             csv_dict = self._read_csv(
                 csv_handler,
-                csv_reader=csv.DictReader,
+                csv_reader=DotDictReader,
                 delimiter=str(delimiter),
                 fieldnames=fieldnames,
                 **kwargs

--- a/Examples/CSVExampleTest.robot
+++ b/Examples/CSVExampleTest.robot
@@ -18,6 +18,11 @@ Read csv file to a dict example test
     @{dict}=    read csv file to associative  ${CURDIR}${/}data.csv
     dictionaries should be equal  ${template_dict}  ${dict[0]}
 
+Read csv file to a dict example test access as attributes
+    @{dict}=    read csv file to associative  ${CURDIR}${/}data.csv
+    Should Be Equal As Strings    ${dict[0].first_name}    ${dict[0]}[first_name]
+    Should Be Equal As Integers    ${dict[0].id}    ${dict[0]}[id]
+    
 Read csv file without quoting to associative
     @{dict}=    read csv file to associative  ${CURDIR}${/}data_quoting.csv  delimiter=,  quoting=${3}
     dictionaries should be equal  ${template_dict_quoting}  ${dict[0]}

--- a/tests/ReadCSVTest.robot
+++ b/tests/ReadCSVTest.robot
@@ -13,6 +13,11 @@ Read csv file to a dict example test
     @{dict}=    Read Csv File To Associative  ${CURDIR}${/}data.csv
     Dictionaries Should Be Equal  ${template_dict_dataFile[-1]}  ${dict[-1]}
 
+Read csv file to a dict example test access as attributes
+    @{dict}=    Read Csv File To Associative  ${CURDIR}${/}data.csv
+    Should Be Equal As Strings    ${template_dict_dataFile[-1].first_name}    ${dict[-1]}[first_name]
+    Should Be Equal As Integers    ${template_dict_dataFile[-1].id}    ${dict[-1]}[id]
+    
 Read csv file without quoting to associative
     @{dict}=    Read Csv File To Associative  ${CURDIR}${/}data_quoting.csv  delimiter=,  quoting=${3}
     Dictionaries Should Be Equal  ${template_dict_quoting}  ${dict[0]}


### PR DESCRIPTION
Subclassed the DictReader to return DotDict instances while reading the CSV